### PR TITLE
Harden VPS monitoring, scheduled health reports, and tmux terminal compatibility

### DIFF
--- a/.cleo/qa/actors/core.yml
+++ b/.cleo/qa/actors/core.yml
@@ -1,0 +1,6 @@
+name: core
+description: Default actor profile for core QA flows.
+surfaces:
+  - web
+  - api
+auth_profile: none

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## Summary
+
+## Why
+
+## What Changed
+
+## How To Test
+
+## Risk
+
+## Rollback
+
+## Ownership
+- Primary:
+- Backup:
+
+## Acceptance Criteria
+<!-- cleo-ac:start -->
+version: 1
+name: Acceptance Criteria
+criteria:
+  - id: c1
+    title: Replace with criterion title
+    severity: medium
+    actors: [core]
+    surface: web
+    environment: local
+    given: Replace with setup state and actor context
+    when: Replace with user/system action under test
+    then:
+      - Replace with observable expected outcome
+    evidence_required:
+      - replace_with_evidence_artifact
+<!-- cleo-ac:end -->
+
+## QA Results
+<!-- cleo-qa-results:start -->
+_No QA report published yet._
+<!-- cleo-qa-results:end -->
+
+## QA Policy
+<!-- cleo-qa-policy:start -->
+mode: auto
+workflow: qa
+<!-- cleo-qa-policy:end -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell-and-json:
+    name: Shell + JSON Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tooling
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Validate shell script syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          found=0
+          while IFS= read -r -d '' file; do
+            found=1
+            bash -n "$file"
+          done < <(find cli/scripts -type f -perm -u+x -print0)
+          if [[ "$found" -eq 0 ]]; then
+            echo "No executable scripts found under cli/scripts"
+          fi
+          bash -n cli/main.sh
+          bash -n install.sh
+
+      - name: Validate JSON files
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq empty settings.json
+          jq empty environment.json
+          jq empty user/user-state.json.example
+          jq empty user/user-state.schema.json

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,82 @@
+name: qa
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qa:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y gh jq curl tar gzip nodejs
+      - shell: bash
+        run: |
+          set -euo pipefail
+          api="https://api.github.com/repos/cafaye/cleo/releases/latest"
+          version="$(curl -fsSL "$api" | jq -r '.tag_name')"
+          asset="cleo_${version}_linux_amd64.tar.gz"
+          url="$(curl -fsSL "$api" | jq -r --arg name "$asset" '.assets[] | select(.name==$name) | .browser_download_url')"
+          curl -fsSL "$url" -o /tmp/cleo.tgz
+          tar -xzf /tmp/cleo.tgz -C /tmp
+          sudo install -m 0755 /tmp/cleo /usr/local/bin/cleo
+      - if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            data="$(gh pr view "$PR_NUMBER" --json statusCheckRollup --jq '.statusCheckRollup')"
+            pending="$(jq '[.[] | select((.workflowName // "" | ascii_downcase) != "qa") | select((.status // "") != "COMPLETED")] | length' <<< "$data")"
+            failed="$(jq '[.[] | select((.workflowName // "" | ascii_downcase) != "qa") | select((.status // "") == "COMPLETED") | select((.conclusion // "SUCCESS") != "SUCCESS" and (.conclusion // "") != "NEUTRAL")] | length' <<< "$data")"
+            if [[ "$failed" -gt 0 ]]; then exit 1; fi
+            if [[ "$pending" -eq 0 ]]; then break; fi
+            sleep 10
+          done
+      - if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          body="$(gh pr view "$PR_NUMBER" --json body --jq .body)"
+          if ! grep -q "<!-- cleo-ac:start -->" <<< "$body" || ! grep -q "<!-- cleo-ac:end -->" <<< "$body"; then
+            echo "No AC markers; skipping."
+            exit 0
+          fi
+          policy="$(awk '/<!-- cleo-qa-policy:start -->/{flag=1;next}/<!-- cleo-qa-policy:end -->/{flag=0}flag' <<< "$body")"
+          mode="$(awk -F: '/^mode:/{print $2; exit}' <<< "$policy" | xargs || true)"
+          if [[ -z "$mode" ]]; then mode="auto"; fi
+          short_sha="$(printf "%s" "$SHA" | cut -c1-7)"
+          goals="CI-gated QA run for PR #${PR_NUMBER} (${short_sha})"
+          sid="$(cleo qa start --source pr --ref "$PR_NUMBER" --goals "$goals" | awk '{print $4}')"
+          cleo qa plan --session "$sid"
+          cleo qa doctor --session "$sid"
+          set +e
+          cleo qa run --session "$sid" --mode "$mode"
+          run_status=$?
+          set -e
+          verdict="pass"
+          if [[ "$run_status" -ne 0 ]]; then verdict="fail"; fi
+          cleo qa finish --session "$sid" --verdict "$verdict"
+          cleo qa report --session "$sid"
+          exit "$run_status"

--- a/Untitled
+++ b/Untitled
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+ignore-words-list = dne

--- a/cleo.yml
+++ b/cleo.yml
@@ -1,0 +1,49 @@
+github:
+    base_branch: master
+    delete_branch_on_merge: false
+    host: github.com
+    merge_method: merge
+    owner: cafaye
+    repo: cafaye
+pr:
+    allow_self_approval: false
+    block_if_requested_changes: true
+    checks:
+        ignore: []
+        mode: required
+        poll_interval_seconds: 10
+        required: []
+        timeout_seconds: 1800
+        treat_neutral_as_pass: false
+    deploy_watch:
+        branch: master
+        enabled: true
+        poll_interval_seconds: 10
+        timeout_seconds: 2700
+        workflow: Deploy to Production
+    post_merge:
+        allow_none: true
+        command_allowlist_prefixes:
+            - bin/kamal
+        command_denylist:
+            - rm -rf /
+        enabled: true
+        markers:
+            end: <!-- post-merge-commands:end -->
+            start: <!-- post-merge-commands:start -->
+        require_command_allowlist: false
+    require_mergeable: true
+    require_non_draft: true
+    required_approvals: 1
+    stack:
+        auto_detect_next_pr: true
+        force_with_lease: true
+        rebase_next_after_merge: true
+qa:
+    actors_dir: .cleo/qa/actors
+    evidence_dir: .cleo/evidence
+    manual:
+        enabled: true
+safety:
+    require_explicit_apply: true
+version: 1

--- a/cli/main.sh
+++ b/cli/main.sh
@@ -162,6 +162,8 @@ run_system_update() {
 show_status_menu() {
     choice=$(caf_choose_menu "Status Submenu" \
         "🏥 System Health" \
+        "📡 VPS Monitoring Setup" \
+        "🧪 Send Monitoring Test Alert" \
         "🏭 Factory CI/CD Status" \
         "👁️  Watch Factory (Live)" \
         "🔍 Check Current Commit" \
@@ -169,6 +171,8 @@ show_status_menu() {
 
     case "$choice" in
         *"System Health"*) show_system_health ;;
+        *"Monitoring Setup"*) caf-vps-monitor-setup ;;
+        *"Test Alert"*) caf-vps-monitor-check --notify-test ;;
         *"Factory CI/CD"*) caf-factory-check ;;
         *"Watch Factory"*) caf-factory-check --watch ;;
         *"Current Commit"*) check_current_commit ;;

--- a/cli/scripts/caf-openclaw-offload
+++ b/cli/scripts/caf-openclaw-offload
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Ephemeral offload runner: create worker, run job, optionally destroy worker.
+
+set -euo pipefail
+
+NAME="${1:-}"
+ZONE="${2:-us-central1-a}"
+MACHINE_TYPE="${3:-e2-small}"
+REPO_URL="${4:-https://github.com/cafaye/cafaye}"
+JOB_CMD="${5:-}"
+KEEP_WORKER="${KEEP_WORKER:-0}"
+
+if [[ -z "$NAME" || -z "$JOB_CMD" ]]; then
+  cat <<EOF
+Usage:
+  caf-openclaw-offload <name> <zone> <machine-type> <repo-url> <job-cmd>
+
+Example:
+  caf-openclaw-offload oc-worker-1 us-central1-a e2-small https://github.com/cafaye/cafaye "cd ~/work/cafaye && caf-test unit"
+EOF
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/caf-openclaw-worker-create" "$NAME" "$ZONE" "$MACHINE_TYPE"
+
+cleanup() {
+  if [[ "$KEEP_WORKER" == "1" ]]; then
+    echo "KEEP_WORKER=1 set; skipping destroy for $NAME"
+    return
+  fi
+  "$SCRIPT_DIR/caf-openclaw-worker-destroy" "$NAME" "$ZONE"
+}
+trap cleanup EXIT
+
+echo "Waiting for startup script to settle..."
+READY=0
+for i in $(seq 1 30); do
+  if "$SCRIPT_DIR/caf-openclaw-worker-run" "$NAME" "$ZONE" "test -f /var/tmp/cafaye-worker-ready && swapon --show | grep -q /swapfile && echo READY" >/tmp/cafaye-worker-ready.log 2>&1; then
+    if grep -q "READY" /tmp/cafaye-worker-ready.log; then
+      READY=1
+      break
+    fi
+  fi
+  sleep 5
+done
+
+if [[ "$READY" != "1" ]]; then
+  echo "Worker readiness check failed (startup marker/swap not ready)."
+  echo "Last readiness output:"
+  cat /tmp/cafaye-worker-ready.log || true
+  exit 1
+fi
+
+REMOTE_BOOTSTRAP=$(cat <<EOF
+set -euo pipefail
+mkdir -p ~/work
+if [[ ! -d ~/work/cafaye/.git ]]; then
+  git clone "$REPO_URL" ~/work/cafaye
+else
+  cd ~/work/cafaye
+  git fetch --all --prune
+fi
+EOF
+)
+
+"$SCRIPT_DIR/caf-openclaw-worker-run" "$NAME" "$ZONE" "$REMOTE_BOOTSTRAP"
+"$SCRIPT_DIR/caf-openclaw-worker-run" "$NAME" "$ZONE" "$JOB_CMD"
+
+echo "Offloaded job finished on $NAME"

--- a/cli/scripts/caf-openclaw-worker-create
+++ b/cli/scripts/caf-openclaw-worker-create
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Create a dedicated OpenClaw worker VM for heavy QA/dev jobs.
+
+set -euo pipefail
+
+NAME="${1:-}"
+ZONE="${2:-us-central1-a}"
+MACHINE_TYPE="${3:-e2-small}"
+PROJECT="${GOOGLE_CLOUD_PROJECT:-cafaye}"
+SSH_USER="${USER:-kaka}"
+
+if [[ -z "$NAME" ]]; then
+  echo "Usage: caf-openclaw-worker-create <name> [zone] [machine-type]"
+  exit 1
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "Error: gcloud is required"
+  exit 1
+fi
+
+if [[ ! -f "$HOME/.ssh/cafaye.pub" ]]; then
+  echo "Error: missing SSH public key at ~/.ssh/cafaye.pub"
+  exit 1
+fi
+
+STARTUP_SCRIPT=$(cat <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+apt-get update -y
+apt-get install -y git curl jq tmux fail2ban ufw
+if ! swapon --show | grep -q /swapfile; then
+  fallocate -l 4G /swapfile || dd if=/dev/zero of=/swapfile bs=1M count=4096
+  chmod 600 /swapfile
+  mkswap /swapfile
+  swapon /swapfile
+fi
+grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+cat >/etc/sysctl.d/99-cafaye-worker.conf <<SYS
+vm.swappiness=10
+vm.vfs_cache_pressure=50
+vm.dirty_background_ratio=5
+vm.dirty_ratio=20
+SYS
+sysctl --system || true
+touch /var/tmp/cafaye-worker-ready
+EOF
+)
+
+echo "Creating worker VM: $NAME ($ZONE, $MACHINE_TYPE) in project $PROJECT"
+gcloud compute instances create "$NAME" \
+  --project="$PROJECT" \
+  --zone="$ZONE" \
+  --machine-type="$MACHINE_TYPE" \
+  --image-project=ubuntu-os-cloud \
+  --image-family=ubuntu-2404-lts-amd64 \
+  --metadata=ssh-keys="${SSH_USER}:$(cat "$HOME/.ssh/cafaye.pub")",startup-script="$STARTUP_SCRIPT" \
+  --labels=owner=cafaye,role=openclaw-worker,managed-by=cafaye \
+  --quiet
+
+IP=$(gcloud compute instances describe "$NAME" --project="$PROJECT" --zone="$ZONE" --format='get(networkInterfaces[0].networkIP)')
+echo "Worker created."
+echo "Name: $NAME"
+echo "Zone: $ZONE"
+echo "IP: $IP"

--- a/cli/scripts/caf-openclaw-worker-destroy
+++ b/cli/scripts/caf-openclaw-worker-destroy
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Destroy a dedicated OpenClaw worker VM.
+
+set -euo pipefail
+
+NAME="${1:-}"
+ZONE="${2:-us-central1-a}"
+PROJECT="${GOOGLE_CLOUD_PROJECT:-cafaye}"
+
+if [[ -z "$NAME" ]]; then
+  echo "Usage: caf-openclaw-worker-destroy <name> [zone]"
+  exit 1
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "Error: gcloud is required"
+  exit 1
+fi
+
+echo "Destroying worker VM: $NAME ($ZONE) in project $PROJECT"
+gcloud compute instances delete "$NAME" \
+  --project="$PROJECT" \
+  --zone="$ZONE" \
+  --quiet
+
+echo "Worker destroyed: $NAME"

--- a/cli/scripts/caf-openclaw-worker-run
+++ b/cli/scripts/caf-openclaw-worker-run
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Run a command on a worker VM over IAP SSH.
+
+set -euo pipefail
+
+NAME="${1:-}"
+ZONE="${2:-us-central1-a}"
+shift 2 || true
+REMOTE_CMD="${*:-}"
+PROJECT="${GOOGLE_CLOUD_PROJECT:-cafaye}"
+SSH_KEY="${HOME}/.ssh/cafaye"
+SSH_USER="${USER:-kaka}"
+
+if [[ -z "$NAME" || -z "$REMOTE_CMD" ]]; then
+  echo "Usage: caf-openclaw-worker-run <name> <zone> <command...>"
+  exit 1
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "Error: gcloud is required"
+  exit 1
+fi
+
+gcloud --quiet compute ssh "${SSH_USER}@${NAME}" \
+  --project="$PROJECT" \
+  --zone="$ZONE" \
+  --tunnel-through-iap \
+  --ssh-key-file="$SSH_KEY" \
+  --command="$REMOTE_CMD"

--- a/cli/scripts/caf-system-doctor
+++ b/cli/scripts/caf-system-doctor
@@ -233,8 +233,8 @@ fi
 echo -n "Checking CPU Load... "
 CPU_LOAD=$(uptime | awk -F'load average:' '{ print $2 }' | cut -d, -f1 | xargs)
 CORES=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
-THRESHOLD=$(echo "$CORES * 2" | bc 2>/dev/null || echo 4)
-if (( $(echo "$CPU_LOAD > $THRESHOLD" | bc -l) )); then
+THRESHOLD=$(awk -v c="$CORES" 'BEGIN { printf "%.2f", c * 2 }')
+if awk -v load="$CPU_LOAD" -v threshold="$THRESHOLD" 'BEGIN { exit !(load > threshold) }'; then
   echo "⚠ High system load ($CPU_LOAD > $THRESHOLD)"
   ((ISSUES++))
 else

--- a/cli/scripts/caf-system-doctor
+++ b/cli/scripts/caf-system-doctor
@@ -180,6 +180,28 @@ if [[ "$MONITORING_ENABLED" == "true" ]]; then
   else
     echo "○ No runs yet"
   fi
+
+  echo -n "Checking scheduled health reports... "
+  REPORT_FREQ=$(jq -r '.core.monitoring.healthcheck_reports.frequency // "none"' "$HOME/.config/cafaye/settings.json" 2>/dev/null || echo "none")
+  if [[ "$REPORT_FREQ" == "none" ]]; then
+    echo "○ Disabled"
+  else
+    if systemctl --user is-active --quiet caf-vps-health-report.timer 2>/dev/null; then
+      REPORT_TIME=$(jq -r '.core.monitoring.healthcheck_reports.time // "09:00"' "$HOME/.config/cafaye/settings.json" 2>/dev/null || echo "09:00")
+      REPORT_DOW=$(jq -r '.core.monitoring.healthcheck_reports.day_of_week // "Mon"' "$HOME/.config/cafaye/settings.json" 2>/dev/null || echo "Mon")
+      REPORT_DOM=$(jq -r '.core.monitoring.healthcheck_reports.day_of_month // 1' "$HOME/.config/cafaye/settings.json" 2>/dev/null || echo "1")
+      if [[ "$REPORT_FREQ" == "weekly" ]]; then
+        echo "✓ Active ($REPORT_FREQ at $REPORT_DOW $REPORT_TIME UTC)"
+      elif [[ "$REPORT_FREQ" == "monthly" ]]; then
+        echo "✓ Active ($REPORT_FREQ on day $REPORT_DOM at $REPORT_TIME UTC)"
+      else
+        echo "✓ Active ($REPORT_FREQ at $REPORT_TIME UTC)"
+      fi
+    else
+      echo "❌ Configured but timer not active"
+      ((ISSUES++))
+    fi
+  fi
 else
   echo "○ Disabled"
 fi

--- a/cli/scripts/caf-system-doctor
+++ b/cli/scripts/caf-system-doctor
@@ -161,6 +161,29 @@ if [[ -f "$HOME/.config/cafaye/settings.json" ]]; then
   fi
 fi
 
+# Check VPS Monitoring
+echo -n "Checking VPS Monitoring... "
+MONITORING_ENABLED=$(jq -r '.core.monitoring.enabled // false' "$HOME/.config/cafaye/settings.json" 2>/dev/null || echo "false")
+if [[ "$MONITORING_ENABLED" == "true" ]]; then
+  if systemctl --user is-active --quiet caf-vps-monitor.timer 2>/dev/null; then
+    MONITOR_PROVIDER=$(jq -r '.core.monitoring.notifier.provider // "none"' "$HOME/.config/cafaye/settings.json" 2>/dev/null || echo "none")
+    echo "✓ Active (provider: $MONITOR_PROVIDER)"
+  else
+    echo "❌ Enabled but timer not active"
+    ((ISSUES++))
+  fi
+
+  echo -n "Checking VPS Monitoring last run... "
+  LAST_RUN=$(systemctl --user show caf-vps-monitor.service -p ExecMainStartTimestamp --value 2>/dev/null || true)
+  if [[ -n "$LAST_RUN" ]]; then
+    echo "✓ $LAST_RUN"
+  else
+    echo "○ No runs yet"
+  fi
+else
+  echo "○ Disabled"
+fi
+
 # Check Backup/Sync Health
 echo -n "Checking Backup Source of Truth... "
 if [[ -d "$HOME/.config/cafaye/.git" ]]; then

--- a/cli/scripts/caf-vps-monitor-check
+++ b/cli/scripts/caf-vps-monitor-check
@@ -9,6 +9,7 @@ STATE_FILE="${STATE_DIR}/monitor-alert-state.json"
 
 QUIET=0
 TEST_NOTIFY=0
+SCHEDULED_REPORT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -18,6 +19,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --notify-test)
       TEST_NOTIFY=1
+      shift
+      ;;
+    --health-report)
+      SCHEDULED_REPORT=1
       shift
       ;;
     *)
@@ -90,16 +95,6 @@ send_notification() {
   esac
 }
 
-if [[ "$TEST_NOTIFY" -eq 1 ]]; then
-  msg="✅ Cafaye VPS monitor test from ${hostname_value} at ${now_human}"
-  if send_notification "$msg"; then
-    log "Test notification sent using provider=${provider}"
-    exit 0
-  fi
-  log "Test notification failed (provider=${provider})"
-  exit 1
-fi
-
 mkdir -p "$STATE_DIR"
 if [[ ! -f "$STATE_FILE" ]]; then
   cat >"$STATE_FILE" <<EOF
@@ -138,6 +133,7 @@ get_state_last_sent() {
 
 alerts=()
 recoveries=()
+failed_processes=()
 
 handle_condition() {
   local key="$1"
@@ -197,6 +193,7 @@ handle_condition "disk" "$disk_hot" "$disk_alert_detail"
 handle_condition "load" "$load_hot" "$load_alert_detail"
 
 process_count="$(read_json '.core.monitoring.processes | length // 0')"
+process_report=()
 if [[ "$process_count" =~ ^[0-9]+$ ]] && [[ "$process_count" -gt 0 ]]; then
   while IFS= read -r proc; do
     [[ -z "$proc" ]] && continue
@@ -213,11 +210,88 @@ if [[ "$process_count" =~ ^[0-9]+$ ]] && [[ "$process_count" -gt 0 ]]; then
       fi
     fi
     if [[ "$proc_ok" == "true" ]]; then
+      process_report+=("- ${proc}: OK")
       handle_condition "proc:${proc}" "false" "Process check failed: ${proc}"
     else
+      process_report+=("- ${proc}: FAIL")
+      failed_processes+=("$proc")
       handle_condition "proc:${proc}" "true" "Process check failed: ${proc}"
     fi
   done < <(jq -r '.core.monitoring.processes[]? // empty' "$SETTINGS_FILE")
+fi
+
+recommendations=()
+[[ "$ram_hot" == "true" ]] && recommendations+=("- RAM is high: restart memory-heavy services, then plan a VPS RAM upgrade if sustained.")
+[[ "$disk_hot" == "true" ]] && recommendations+=("- Disk is high: clean logs/caches, rotate logs, and free space on '/'.")
+[[ "$load_hot" == "true" ]] && recommendations+=("- CPU load/core is high: inspect top processes and reduce background jobs or scale up CPU.")
+if [[ "${#failed_processes[@]}" -gt 0 ]]; then
+  recommendations+=("- One or more critical processes are down: restart and check logs.")
+fi
+if [[ "${#recommendations[@]}" -eq 0 ]]; then
+  recommendations+=("- System is healthy. Keep monitoring enabled and review trends weekly.")
+fi
+
+if [[ "$TEST_NOTIFY" -eq 1 || "$SCHEDULED_REPORT" -eq 1 ]]; then
+  if [[ "$SCHEDULED_REPORT" -eq 1 ]]; then
+    snapshot_title="🗓️ Cafaye Scheduled VPS Health Report"
+  else
+    snapshot_title="🩺 Cafaye VPS Health Snapshot"
+  fi
+  test_lines=()
+  test_lines+=("${snapshot_title}")
+  test_lines+=("Host: ${hostname_value}")
+  test_lines+=("Time: ${now_human}")
+  test_lines+=("Notifier: ${provider}")
+  test_lines+=("")
+  test_lines+=("Current metrics:")
+  test_lines+=("- RAM: ${mem_used_percent}% (threshold ${ram_threshold}%)")
+  test_lines+=("- Disk /: ${disk_used_percent}% (threshold ${disk_threshold}%)")
+  test_lines+=("- Load/Core: ${load_per_core} (threshold ${load_threshold})")
+  if [[ "${#process_report[@]}" -gt 0 ]]; then
+    test_lines+=("- Processes:")
+    for line in "${process_report[@]}"; do
+      test_lines+=("  ${line}")
+    done
+  fi
+  current_issues=()
+  [[ "$ram_hot" == "true" ]] && current_issues+=("RAM high")
+  [[ "$disk_hot" == "true" ]] && current_issues+=("Disk high")
+  [[ "$load_hot" == "true" ]] && current_issues+=("CPU load high")
+  if [[ "${#failed_processes[@]}" -gt 0 ]]; then
+    current_issues+=("Process down: $(IFS=', '; echo "${failed_processes[*]}")")
+  fi
+  test_lines+=("")
+  if [[ "${#current_issues[@]}" -gt 0 ]]; then
+    test_lines+=("Overall status: NEEDS_ATTENTION")
+    test_lines+=("Active issues: $(IFS=' | '; echo "${current_issues[*]}")")
+  else
+    test_lines+=("Overall status: HEALTHY")
+    test_lines+=("Active issues: none")
+  fi
+  test_lines+=("")
+  test_lines+=("Recommended next actions:")
+  for rec in "${recommendations[@]}"; do
+    test_lines+=("${rec}")
+  done
+
+  msg="$(printf '%s\n' "${test_lines[@]}")"
+  if send_notification "$msg"; then
+    if [[ "$SCHEDULED_REPORT" -eq 1 ]]; then
+      log "Scheduled health report sent using provider=${provider}"
+    else
+      log "Health snapshot notification sent using provider=${provider}"
+    fi
+    rm -f "$tmp_state"
+    exit 0
+  fi
+  if [[ "$SCHEDULED_REPORT" -eq 1 ]]; then
+    log "Scheduled health report notification failed (provider=${provider})"
+  else
+    log "Health snapshot notification failed (provider=${provider})"
+  fi
+  rm -f "$tmp_state"
+  [[ "$SCHEDULED_REPORT" -eq 1 ]] && exit 0
+  exit 1
 fi
 
 cp "$tmp_state" "$STATE_FILE"
@@ -230,18 +304,28 @@ fi
 
 message_lines=()
 if [[ "${#alerts[@]}" -gt 0 ]]; then
-  message_lines+=("🚨 Cafaye VPS Alert on ${hostname_value} (${now_human})")
+  message_lines+=("🚨 Cafaye VPS Alert")
+  message_lines+=("Host: ${hostname_value}")
+  message_lines+=("Time: ${now_human}")
+  message_lines+=("Overall status: NEEDS_ATTENTION")
+  message_lines+=("")
+  message_lines+=("Triggered checks:")
   for item in "${alerts[@]}"; do
     message_lines+=("- ${item}")
   done
 fi
 if [[ "${#recoveries[@]}" -gt 0 ]]; then
   [[ "${#alerts[@]}" -gt 0 ]] && message_lines+=("")
-  message_lines+=("✅ Recovered:")
+  message_lines+=("✅ Recovered checks:")
   for item in "${recoveries[@]}"; do
     message_lines+=("- ${item}")
   done
 fi
+message_lines+=("")
+message_lines+=("Recommended next actions:")
+for rec in "${recommendations[@]}"; do
+  message_lines+=("${rec}")
+done
 
 message="$(printf '%s\n' "${message_lines[@]}")"
 

--- a/cli/scripts/caf-vps-monitor-check
+++ b/cli/scripts/caf-vps-monitor-check
@@ -1,0 +1,254 @@
+#!/bin/bash
+
+set -u
+
+CONFIG_DIR="${HOME}/.config/cafaye"
+SETTINGS_FILE="${CONFIG_DIR}/settings.json"
+STATE_DIR="${HOME}/.local/state/cafaye"
+STATE_FILE="${STATE_DIR}/monitor-alert-state.json"
+
+QUIET=0
+TEST_NOTIFY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    --notify-test)
+      TEST_NOTIFY=1
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+log() {
+  [[ "$QUIET" -eq 1 ]] && return 0
+  echo "$@"
+}
+
+if [[ ! -f "$SETTINGS_FILE" ]]; then
+  log "settings.json not found at $SETTINGS_FILE"
+  exit 0
+fi
+
+read_json() {
+  local expr="$1"
+  jq -r "$expr" "$SETTINGS_FILE" 2>/dev/null
+}
+
+enabled="$(read_json '.core.monitoring.enabled // false')"
+if [[ "$enabled" != "true" ]]; then
+  log "Monitoring disabled"
+  exit 0
+fi
+
+interval_minutes="$(read_json '.core.monitoring.check_interval_minutes // 5')"
+ram_threshold="$(read_json '.core.monitoring.thresholds.ram_percent // 75')"
+disk_threshold="$(read_json '.core.monitoring.thresholds.disk_percent // 80')"
+load_threshold="$(read_json '.core.monitoring.thresholds.load_per_core // 0.7')"
+repeat_minutes="$(read_json '.core.monitoring.repeat_alert_minutes // 30')"
+
+provider="$(read_json '.core.monitoring.notifier.provider // "none"')"
+telegram_token="$(read_json '.core.monitoring.notifier.telegram.bot_token // ""')"
+telegram_chat_id="$(read_json '.core.monitoring.notifier.telegram.chat_id // ""')"
+discord_webhook="$(read_json '.core.monitoring.notifier.discord.webhook_url // ""')"
+slack_webhook="$(read_json '.core.monitoring.notifier.slack.webhook_url // ""')"
+
+hostname_value="$(hostname 2>/dev/null || echo unknown-host)"
+now_epoch="$(date +%s)"
+now_human="$(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+
+send_notification() {
+  local message="$1"
+
+  case "$provider" in
+    telegram)
+      [[ -z "$telegram_token" || -z "$telegram_chat_id" ]] && return 1
+      curl -fsS -X POST "https://api.telegram.org/bot${telegram_token}/sendMessage" \
+        -d "chat_id=${telegram_chat_id}" \
+        --data-urlencode "text=${message}" >/dev/null
+      ;;
+    discord)
+      [[ -z "$discord_webhook" ]] && return 1
+      curl -fsS -H "Content-Type: application/json" -X POST "$discord_webhook" \
+        -d "$(printf '%s' "$message" | jq -Rs '{content: .}')" >/dev/null
+      ;;
+    slack)
+      [[ -z "$slack_webhook" ]] && return 1
+      curl -fsS -H "Content-Type: application/json" -X POST "$slack_webhook" \
+        -d "$(printf '%s' "$message" | jq -Rs '{text: .}')" >/dev/null
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [[ "$TEST_NOTIFY" -eq 1 ]]; then
+  msg="✅ Cafaye VPS monitor test from ${hostname_value} at ${now_human}"
+  if send_notification "$msg"; then
+    log "Test notification sent using provider=${provider}"
+    exit 0
+  fi
+  log "Test notification failed (provider=${provider})"
+  exit 1
+fi
+
+mkdir -p "$STATE_DIR"
+if [[ ! -f "$STATE_FILE" ]]; then
+  cat >"$STATE_FILE" <<EOF
+{"active":{},"last_sent":{}}
+EOF
+fi
+
+tmp_state="$(mktemp)"
+cp "$STATE_FILE" "$tmp_state"
+
+set_state_bool() {
+  local key="$1"
+  local value="$2"
+  local tmp="$(mktemp)"
+  jq --arg k "$key" --argjson v "$value" '.active[$k] = $v' "$tmp_state" >"$tmp"
+  mv "$tmp" "$tmp_state"
+}
+
+set_state_last_sent() {
+  local key="$1"
+  local value="$2"
+  local tmp="$(mktemp)"
+  jq --arg k "$key" --argjson v "$value" '.last_sent[$k] = $v' "$tmp_state" >"$tmp"
+  mv "$tmp" "$tmp_state"
+}
+
+get_state_bool() {
+  local key="$1"
+  jq -r --arg k "$key" '.active[$k] // false' "$tmp_state" 2>/dev/null
+}
+
+get_state_last_sent() {
+  local key="$1"
+  jq -r --arg k "$key" '.last_sent[$k] // 0' "$tmp_state" 2>/dev/null
+}
+
+alerts=()
+recoveries=()
+
+handle_condition() {
+  local key="$1"
+  local active_now="$2"
+  local detail="$3"
+  local previous_active
+  local previous_sent
+  local next_repeat_at
+
+  previous_active="$(get_state_bool "$key")"
+  previous_sent="$(get_state_last_sent "$key")"
+  next_repeat_at=$((previous_sent + repeat_minutes * 60))
+
+  if [[ "$active_now" == "true" ]]; then
+    if [[ "$previous_active" != "true" ]]; then
+      alerts+=("$detail")
+      set_state_last_sent "$key" "$now_epoch"
+    elif [[ "$now_epoch" -ge "$next_repeat_at" ]]; then
+      alerts+=("$detail (still ongoing)")
+      set_state_last_sent "$key" "$now_epoch"
+    fi
+    set_state_bool "$key" true
+  else
+    if [[ "$previous_active" == "true" ]]; then
+      recoveries+=("$detail")
+    fi
+    set_state_bool "$key" false
+  fi
+}
+
+if command -v free >/dev/null 2>&1; then
+  mem_used_percent="$(free | awk '/^Mem:/ { if ($2 == 0) { print 0 } else { printf "%.0f", ($3/$2)*100 } }')"
+else
+  mem_used_percent="$(
+    awk '/MemTotal:/ {t=$2} /MemAvailable:/ {a=$2} END { if (t == 0) { print 0 } else { printf "%.0f", ((t-a)/t)*100 } }' /proc/meminfo 2>/dev/null || echo 0
+  )"
+fi
+disk_used_percent="$(df / | awk 'NR==2 {gsub("%","",$5); print $5}' 2>/dev/null || echo 0)"
+if [[ -r /proc/loadavg ]]; then
+  load_1m="$(awk '{print $1}' /proc/loadavg)"
+else
+  load_1m="$(uptime 2>/dev/null | awk -F'load averages?: ' '{print $2}' | cut -d',' -f1 | xargs || echo 0)"
+fi
+cores="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)"
+load_per_core="$(awk -v l="$load_1m" -v c="$cores" 'BEGIN { if (c <= 0) c=1; printf "%.2f", l/c }')"
+
+ram_alert_detail="RAM ${mem_used_percent}% (threshold ${ram_threshold}%)"
+disk_alert_detail="Disk / ${disk_used_percent}% (threshold ${disk_threshold}%)"
+load_alert_detail="CPU load/core ${load_per_core} (threshold ${load_threshold})"
+
+ram_hot="$(awk -v x="$mem_used_percent" -v y="$ram_threshold" 'BEGIN { print (x >= y) ? "true" : "false" }')"
+disk_hot="$(awk -v x="$disk_used_percent" -v y="$disk_threshold" 'BEGIN { print (x >= y) ? "true" : "false" }')"
+load_hot="$(awk -v x="$load_per_core" -v y="$load_threshold" 'BEGIN { print (x >= y) ? "true" : "false" }')"
+
+handle_condition "ram" "$ram_hot" "$ram_alert_detail"
+handle_condition "disk" "$disk_hot" "$disk_alert_detail"
+handle_condition "load" "$load_hot" "$load_alert_detail"
+
+process_count="$(read_json '.core.monitoring.processes | length // 0')"
+if [[ "$process_count" =~ ^[0-9]+$ ]] && [[ "$process_count" -gt 0 ]]; then
+  while IFS= read -r proc; do
+    [[ -z "$proc" ]] && continue
+    proc_ok="false"
+    if systemctl is-active --quiet "$proc" 2>/dev/null || systemctl is-active --quiet "${proc}.service" 2>/dev/null; then
+      proc_ok="true"
+    elif [[ "$proc" == *" "* || "$proc" == *"/"* ]]; then
+      if pgrep -f "$proc" >/dev/null 2>&1; then
+        proc_ok="true"
+      fi
+    else
+      if pgrep -x "$proc" >/dev/null 2>&1; then
+        proc_ok="true"
+      fi
+    fi
+    if [[ "$proc_ok" == "true" ]]; then
+      handle_condition "proc:${proc}" "false" "Process check failed: ${proc}"
+    else
+      handle_condition "proc:${proc}" "true" "Process check failed: ${proc}"
+    fi
+  done < <(jq -r '.core.monitoring.processes[]? // empty' "$SETTINGS_FILE")
+fi
+
+cp "$tmp_state" "$STATE_FILE"
+rm -f "$tmp_state"
+
+if [[ "${#alerts[@]}" -eq 0 && "${#recoveries[@]}" -eq 0 ]]; then
+  log "No new alerts (${now_human})"
+  exit 0
+fi
+
+message_lines=()
+if [[ "${#alerts[@]}" -gt 0 ]]; then
+  message_lines+=("🚨 Cafaye VPS Alert on ${hostname_value} (${now_human})")
+  for item in "${alerts[@]}"; do
+    message_lines+=("- ${item}")
+  done
+fi
+if [[ "${#recoveries[@]}" -gt 0 ]]; then
+  [[ "${#alerts[@]}" -gt 0 ]] && message_lines+=("")
+  message_lines+=("✅ Recovered:")
+  for item in "${recoveries[@]}"; do
+    message_lines+=("- ${item}")
+  done
+fi
+
+message="$(printf '%s\n' "${message_lines[@]}")"
+
+if send_notification "$message"; then
+  log "Notification sent via ${provider}"
+else
+  log "Notification not sent (provider=${provider}, missing/invalid config)"
+fi
+
+exit 0

--- a/cli/scripts/caf-vps-monitor-setup
+++ b/cli/scripts/caf-vps-monitor-setup
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CONFIG_DIR="${HOME}/.config/cafaye"
+SETTINGS_FILE="${CONFIG_DIR}/settings.json"
+
+mkdir -p "$CONFIG_DIR"
+[[ -f "$SETTINGS_FILE" ]] || echo "{}" > "$SETTINGS_FILE"
+
+choose_option() {
+  local prompt="$1"
+  shift
+  local options=("$@")
+
+  if command -v gum >/dev/null 2>&1; then
+    gum choose --header "$prompt" "${options[@]}"
+  else
+    echo "$prompt"
+    local i=1
+    for o in "${options[@]}"; do
+      echo "$i) $o"
+      i=$((i + 1))
+    done
+    read -r -p "Select [1-${#options[@]}]: " idx
+    idx=$((idx - 1))
+    echo "${options[$idx]}"
+  fi
+}
+
+prompt_text() {
+  local prompt="$1"
+  local default="${2:-}"
+  local value=""
+  if command -v gum >/dev/null 2>&1; then
+    if [[ -n "$default" ]]; then
+      value="$(gum input --prompt "$prompt " --value "$default")"
+    else
+      value="$(gum input --prompt "$prompt ")"
+    fi
+  else
+    if [[ -n "$default" ]]; then
+      read -r -p "$prompt [$default]: " value
+      value="${value:-$default}"
+    else
+      read -r -p "$prompt: " value
+    fi
+  fi
+  echo "$value"
+}
+
+write_settings() {
+  local jq_filter="$1"
+  local tmp
+  tmp="$(mktemp)"
+  jq "$jq_filter" "$SETTINGS_FILE" > "$tmp"
+  mv "$tmp" "$SETTINGS_FILE"
+}
+
+echo "📡 Cafaye VPS Monitoring Setup"
+echo ""
+echo "This enables periodic health checks and optional alerts."
+echo ""
+
+enabled_choice="$(choose_option "Enable VPS monitoring?" "yes" "no")"
+if [[ "$enabled_choice" != "yes" ]]; then
+  write_settings '.core.monitoring.enabled = false'
+  echo "Monitoring disabled in settings."
+  exit 0
+fi
+
+interval="$(prompt_text "Check interval minutes" "5")"
+ram_threshold="$(prompt_text "RAM alert threshold (%)" "75")"
+disk_threshold="$(prompt_text "Disk alert threshold (%)" "80")"
+load_threshold="$(prompt_text "CPU load-per-core threshold" "0.7")"
+repeat_minutes="$(prompt_text "Repeat alert every N minutes while ongoing" "30")"
+
+processes_raw="$(prompt_text "Critical processes/services (comma separated, optional)" "postgresql,redis")"
+if [[ -n "$processes_raw" ]]; then
+  processes_json="$(printf '%s' "$processes_raw" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length>0))')"
+else
+  processes_json="[]"
+fi
+
+provider="$(choose_option "Alert provider" "none" "telegram" "discord" "slack")"
+
+telegram_token=""
+telegram_chat_id=""
+discord_webhook=""
+slack_webhook=""
+
+case "$provider" in
+  telegram)
+    telegram_token="$(prompt_text "Telegram bot token")"
+    telegram_chat_id="$(prompt_text "Telegram chat ID")"
+    ;;
+  discord)
+    discord_webhook="$(prompt_text "Discord webhook URL")"
+    ;;
+  slack)
+    slack_webhook="$(prompt_text "Slack incoming webhook URL")"
+    ;;
+esac
+
+tmp="$(mktemp)"
+jq \
+  --argjson interval "$interval" \
+  --argjson ram "$ram_threshold" \
+  --argjson disk "$disk_threshold" \
+  --argjson load "$load_threshold" \
+  --argjson repeat "$repeat_minutes" \
+  --arg provider "$provider" \
+  --arg tg_token "$telegram_token" \
+  --arg tg_chat "$telegram_chat_id" \
+  --arg dc_webhook "$discord_webhook" \
+  --arg sl_webhook "$slack_webhook" \
+  --argjson procs "$processes_json" \
+  '
+  .core.monitoring.enabled = true
+  | .core.monitoring.check_interval_minutes = $interval
+  | .core.monitoring.repeat_alert_minutes = $repeat
+  | .core.monitoring.thresholds.ram_percent = $ram
+  | .core.monitoring.thresholds.disk_percent = $disk
+  | .core.monitoring.thresholds.load_per_core = $load
+  | .core.monitoring.processes = $procs
+  | .core.monitoring.notifier.provider = $provider
+  | .core.monitoring.notifier.telegram.bot_token = $tg_token
+  | .core.monitoring.notifier.telegram.chat_id = $tg_chat
+  | .core.monitoring.notifier.discord.webhook_url = $dc_webhook
+  | .core.monitoring.notifier.slack.webhook_url = $sl_webhook
+  ' "$SETTINGS_FILE" > "$tmp"
+mv "$tmp" "$SETTINGS_FILE"
+
+echo ""
+echo "✅ Monitoring configuration saved to $SETTINGS_FILE"
+echo "Next steps:"
+echo "1) Run: caf-system-rebuild"
+echo "2) Run: caf-vps-monitor-check --notify-test"

--- a/cli/scripts/caf-vps-monitor-setup
+++ b/cli/scripts/caf-vps-monitor-setup
@@ -74,6 +74,16 @@ ram_threshold="$(prompt_text "RAM alert threshold (%)" "75")"
 disk_threshold="$(prompt_text "Disk alert threshold (%)" "80")"
 load_threshold="$(prompt_text "CPU load-per-core threshold" "0.7")"
 repeat_minutes="$(prompt_text "Repeat alert every N minutes while ongoing" "30")"
+report_frequency="$(choose_option "Scheduled health reports" "none" "daily" "weekly" "monthly")"
+report_time="$(prompt_text "Scheduled report time (HH:MM, UTC)" "09:00")"
+report_day_of_week="Mon"
+report_day_of_month="1"
+if [[ "$report_frequency" == "weekly" ]]; then
+  report_day_of_week="$(choose_option "Weekly report day" "Mon" "Tue" "Wed" "Thu" "Fri" "Sat" "Sun")"
+fi
+if [[ "$report_frequency" == "monthly" ]]; then
+  report_day_of_month="$(prompt_text "Monthly report day (1-31)" "1")"
+fi
 
 processes_raw="$(prompt_text "Critical processes/services (comma separated, optional)" "postgresql,redis")"
 if [[ -n "$processes_raw" ]]; then
@@ -109,6 +119,10 @@ jq \
   --argjson disk "$disk_threshold" \
   --argjson load "$load_threshold" \
   --argjson repeat "$repeat_minutes" \
+  --arg report_frequency "$report_frequency" \
+  --arg report_time "$report_time" \
+  --arg report_day_of_week "$report_day_of_week" \
+  --argjson report_day_of_month "$report_day_of_month" \
   --arg provider "$provider" \
   --arg tg_token "$telegram_token" \
   --arg tg_chat "$telegram_chat_id" \
@@ -128,6 +142,10 @@ jq \
   | .core.monitoring.notifier.telegram.chat_id = $tg_chat
   | .core.monitoring.notifier.discord.webhook_url = $dc_webhook
   | .core.monitoring.notifier.slack.webhook_url = $sl_webhook
+  | .core.monitoring.healthcheck_reports.frequency = $report_frequency
+  | .core.monitoring.healthcheck_reports.time = $report_time
+  | .core.monitoring.healthcheck_reports.day_of_week = $report_day_of_week
+  | .core.monitoring.healthcheck_reports.day_of_month = $report_day_of_month
   ' "$SETTINGS_FILE" > "$tmp"
 mv "$tmp" "$SETTINGS_FILE"
 

--- a/config/user/tmux/tmux-256color-italic.terminfo
+++ b/config/user/tmux/tmux-256color-italic.terminfo
@@ -1,0 +1,4 @@
+tmux-256color-italic|tmux with 256 colors and italic,
+  use=tmux-256color,
+  sitm=\E[3m,
+  ritm=\E[23m,

--- a/config/user/tmux/tmux.conf
+++ b/config/user/tmux/tmux.conf
@@ -34,8 +34,7 @@
 set -g default-shell $SHELL
 
 # tmux display things in 256 colors
-set -g default-terminal "tmux-256color-italic"
-# set -as terminal-overrides ',xterm*:Tc:sitm=\E[3m'
+if-shell "infocmp tmux-256color-italic >/dev/null 2>&1" "set -g default-terminal \"tmux-256color-italic\"" "set -g default-terminal \"tmux-256color\""
 set -ga terminal-overrides ",*256col*:Tc"
 
 set -g history-limit 20000

--- a/docs/VPS-INSTALL.md
+++ b/docs/VPS-INSTALL.md
@@ -107,6 +107,14 @@ What Cafaye monitors by default:
 - CPU load per core
 - Critical processes/services you define
 
+Optional scheduled health reports:
+- `none` (disabled)
+- `daily` (choose time)
+- `weekly` (choose day + time)
+- `monthly` (choose date + time)
+
+These send a full health snapshot even when there is no incident.
+
 Useful health checks:
 
 ```bash

--- a/docs/VPS-INSTALL.md
+++ b/docs/VPS-INSTALL.md
@@ -80,6 +80,43 @@ caf apply
 caf ci status --latest
 ```
 
+## 📡 Three-Layer Monitoring (Recommended)
+
+For low-cost VPS reliability, use all three layers:
+
+1. **Layer 1 (dashboard):** Install Netdata for real-time host metrics.
+2. **Layer 2 (alerts):** Use Cafaye's built-in periodic health alerts.
+3. **Layer 3 (external):** Add UptimeRobot/Better Stack checks from outside your VPS.
+
+### Layer 2: Cafaye Alerts (Easy Setup)
+
+```bash
+# Interactive setup (provider optional: none, telegram, discord, slack)
+caf-vps-monitor-setup
+
+# Apply system changes (enables timer when monitoring is enabled)
+caf-system-rebuild
+
+# Send a test notification
+caf-vps-monitor-check --notify-test
+```
+
+What Cafaye monitors by default:
+- RAM usage (%)
+- Disk usage on `/` (%)
+- CPU load per core
+- Critical processes/services you define
+
+Useful health checks:
+
+```bash
+# Verify monitor timer and last run
+caf-system-doctor
+
+# Run one immediate check
+caf-vps-monitor-check
+```
+
 ---
 
 ## 🏗 Fleet Integration

--- a/docs/profiles/openclaw.md
+++ b/docs/profiles/openclaw.md
@@ -99,13 +99,110 @@ It is intentionally environment-agnostic and should be used across teams/project
 - [ ] Document fallback admin access path (for example private tunnel or IAP).
 - [ ] Keep an incident runbook for channel failures, auth failures, and gateway restart loops.
 
-## 11) Operational Defaults
+## 11) Capacity and SSH Resilience (Heavy Task Stability)
+
+- [ ] Add swap on small VPS shapes (recommended: `4G` minimum) and persist in `/etc/fstab`.
+- [ ] Apply kernel memory/IO guardrails:
+  - `vm.swappiness=10`
+  - `vm.vfs_cache_pressure=50`
+  - `vm.dirty_background_ratio=5`
+  - `vm.dirty_ratio=20`
+- [ ] Enable SSH keepalive hardening:
+  - `ClientAliveInterval 30`
+  - `ClientAliveCountMax 5`
+  - `TCPKeepAlive yes`
+- [ ] Cap OpenClaw pressure on small hosts:
+  - lower `agents.defaults.maxConcurrent`
+  - set conservative process scheduling for gateway service (`Nice`, `IOScheduling*`, optional `CPUQuota`)
+- [ ] Prefer non-interactive admin paths (`IAP` and/or `Tailscale`) and keep one fallback path available.
+- [ ] Treat Tailscale health warnings as first-class signals when remote shell drops are observed.
+
+## 12) Stability Validation (Post-Hardening)
+
+- [ ] Baseline check:
+  - `free -h`
+  - `swapon --show`
+  - `uptime`
+- [ ] Run repeated remote probes before and during a heavy OpenClaw operation.
+- [ ] Pass criteria:
+  - no SSH probe failures/timeouts during the stress window
+  - gateway remains reachable
+  - no critical findings in `openclaw security audit`
+- [ ] If probes fail:
+  - reduce concurrency further
+  - move to larger machine size
+  - split heavy workloads onto disposable test hosts
+
+## 13) Incident Pattern to Watch
+
+- [ ] Symptom cluster indicating resource/network instability:
+  - SSH banner timeouts or dropped tunnels under load
+  - very high load averages on low-core hosts
+  - high IO wait and delayed service responses
+  - intermittent relay/control-plane health warnings
+- [ ] Response sequence:
+  1. reduce runtime pressure immediately
+  2. confirm swap + sysctl + SSH keepalives
+  3. restart gateway cleanly
+  4. rerun probe-based stress test
+
+## 14) Worker Offloading Pattern (Recommended)
+
+- [ ] Keep OpenClaw gateway/channels on a control-plane host only.
+- [ ] Run heavy QA/build/test/fix loops on separate worker VMs.
+- [ ] Prefer disposable workers per job or per short batch.
+- [ ] Keep worker scripts guarded and reproducible.
+
+### Suggested command flow
+
+1. Create worker:
+   - `caf-openclaw-worker-create <name> [zone] [machine-type]`
+   - default machine type: `e2-small`
+2. Run one remote command:
+   - `caf-openclaw-worker-run <name> <zone> "<command...>"`
+3. Run full ephemeral offload job:
+   - `caf-openclaw-offload <name> <zone> <machine-type> <repo-url> "<job-cmd>"`
+   - recommended starter: `e2-small`
+4. Destroy worker:
+   - `caf-openclaw-worker-destroy <name> [zone]`
+
+### Worker baseline contents
+
+- [ ] Base ops tools (`git`, `curl`, `jq`, `tmux`, `ufw`, `fail2ban`)
+- [ ] Swap enabled (minimum `4G`)
+- [ ] sysctl tuning for memory/IO behavior
+- [ ] project checkout under `~/work/<repo>`
+- [ ] no channel credentials unless explicitly needed
+
+### Worker readiness gate
+
+- [ ] Offload runner should wait for:
+  - startup marker file: `/var/tmp/cafaye-worker-ready`
+  - swap active: `swapon --show` contains `/swapfile`
+- [ ] Fail fast if readiness conditions are not met before job start.
+
+## 15) QA Continuity Memory (No Repeated QA)
+
+- [ ] Maintain per-project QA state file:
+  - `/home/kaka/.openclaw/workspace/projects/<project-key>-qa-state.md`
+- [ ] Required sections:
+  - `Tested (completed)`
+  - `Reported (issues filed)`
+  - `Not Worked (queued)`
+  - `Retest Required`
+- [ ] QA run policy:
+  - always read state file first
+  - prioritize `Not Worked` then `Retest Required`
+  - skip `Tested` unless user requests full rerun or code changed in area
+  - update state file at end of every QA run with timestamps and links
+
+## 16) Operational Defaults
 
 - [ ] Keep heartbeat disabled for request/response-only deployments.
 - [ ] Enable heartbeat only when proactive checks/reminders are required.
 - [ ] Keep automation off until smoke tests and policy controls are verified.
 
-## 12) Definition of Done
+## 17) Definition of Done
 
 - [ ] Gateway is private, authenticated, and reachable via approved admin path.
 - [ ] Channels are connected and correctly routed to target agents.

--- a/home.nix
+++ b/home.nix
@@ -17,6 +17,7 @@
     ./modules/core/sops.nix
     ./modules/core/tailscale.nix
     ./modules/core/vps.nix
+    ./modules/core/monitoring.nix
     
     # Optional Stacks (Managed via sub-imports)
     ./modules/languages

--- a/modules/core/monitoring.nix
+++ b/modules/core/monitoring.nix
@@ -4,6 +4,19 @@ let
   cfg = (userState.core or {}).monitoring or {};
   enabled = cfg.enabled or false;
   intervalMinutes = toString (cfg.check_interval_minutes or 5);
+  reportCfg = cfg.healthcheck_reports or {};
+  reportFrequency = reportCfg.frequency or "none";
+  reportTime = reportCfg.time or "09:00";
+  reportDayOfWeek = reportCfg.day_of_week or "Mon";
+  reportDayOfMonth = toString (reportCfg.day_of_month or 1);
+  timeParts = lib.splitString ":" reportTime;
+  reportHour = if builtins.length timeParts > 0 then builtins.elemAt timeParts 0 else "09";
+  reportMinute = if builtins.length timeParts > 1 then builtins.elemAt timeParts 1 else "00";
+  reportOnCalendar =
+    if reportFrequency == "daily" then "*-*-* ${reportHour}:${reportMinute}:00"
+    else if reportFrequency == "weekly" then "${reportDayOfWeek} *-*-* ${reportHour}:${reportMinute}:00"
+    else if reportFrequency == "monthly" then "*-*-${reportDayOfMonth} ${reportHour}:${reportMinute}:00"
+    else "";
 
   monitorRunner = pkgs.writeShellScriptBin "caf-vps-monitor-runner" ''
     if command -v caf-vps-monitor-check >/dev/null 2>&1; then
@@ -16,10 +29,22 @@ let
 
     exit 0
   '';
+
+  reportRunner = pkgs.writeShellScriptBin "caf-vps-health-report-runner" ''
+    if command -v caf-vps-monitor-check >/dev/null 2>&1; then
+      exec caf-vps-monitor-check --health-report --quiet
+    fi
+
+    if [ -x "$HOME/.config/cafaye/cli/scripts/caf-vps-monitor-check" ]; then
+      exec "$HOME/.config/cafaye/cli/scripts/caf-vps-monitor-check" --health-report --quiet
+    fi
+
+    exit 0
+  '';
 in
 {
   config = lib.mkIf enabled {
-    home.packages = [ monitorRunner ];
+    home.packages = [ monitorRunner reportRunner ];
 
     systemd.user.services.caf-vps-monitor = {
       Unit = {
@@ -38,6 +63,30 @@ in
       Timer = {
         OnCalendar = "*:0/${intervalMinutes}";
         Unit = "caf-vps-monitor.service";
+        Persistent = true;
+      };
+      Install = {
+        WantedBy = [ "timers.target" ];
+      };
+    };
+
+    systemd.user.services.caf-vps-health-report = lib.mkIf (reportFrequency != "none") {
+      Unit = {
+        Description = "Cafaye VPS Scheduled Health Report";
+      };
+      Service = {
+        ExecStart = "${reportRunner}/bin/caf-vps-health-report-runner";
+        Type = "oneshot";
+      };
+    };
+
+    systemd.user.timers.caf-vps-health-report = lib.mkIf (reportFrequency != "none") {
+      Unit = {
+        Description = "Cafaye VPS Scheduled Health Report Timer";
+      };
+      Timer = {
+        OnCalendar = reportOnCalendar;
+        Unit = "caf-vps-health-report.service";
         Persistent = true;
       };
       Install = {

--- a/modules/core/monitoring.nix
+++ b/modules/core/monitoring.nix
@@ -1,0 +1,48 @@
+{ config, pkgs, lib, userState, ... }:
+
+let
+  cfg = (userState.core or {}).monitoring or {};
+  enabled = cfg.enabled or false;
+  intervalMinutes = toString (cfg.check_interval_minutes or 5);
+
+  monitorRunner = pkgs.writeShellScriptBin "caf-vps-monitor-runner" ''
+    if command -v caf-vps-monitor-check >/dev/null 2>&1; then
+      exec caf-vps-monitor-check --quiet
+    fi
+
+    if [ -x "$HOME/.config/cafaye/cli/scripts/caf-vps-monitor-check" ]; then
+      exec "$HOME/.config/cafaye/cli/scripts/caf-vps-monitor-check" --quiet
+    fi
+
+    exit 0
+  '';
+in
+{
+  config = lib.mkIf enabled {
+    home.packages = [ monitorRunner ];
+
+    systemd.user.services.caf-vps-monitor = {
+      Unit = {
+        Description = "Cafaye VPS Monitoring Check";
+      };
+      Service = {
+        ExecStart = "${monitorRunner}/bin/caf-vps-monitor-runner";
+        Type = "oneshot";
+      };
+    };
+
+    systemd.user.timers.caf-vps-monitor = {
+      Unit = {
+        Description = "Cafaye VPS Monitoring Timer";
+      };
+      Timer = {
+        OnCalendar = "*:0/${intervalMinutes}";
+        Unit = "caf-vps-monitor.service";
+        Persistent = true;
+      };
+      Install = {
+        WantedBy = [ "timers.target" ];
+      };
+    };
+  };
+}

--- a/modules/interface/terminal/tmux.nix
+++ b/modules/interface/terminal/tmux.nix
@@ -33,6 +33,7 @@ in
 
     # Link the theme script to the expected location
     xdg.configFile."tmux/base16.sh".source = ../../../config/user/tmux/base16.sh;
+    xdg.configFile."tmux/tmux-256color-italic.terminfo".source = ../../../config/user/tmux/tmux-256color-italic.terminfo;
 
     # Ensure TPM/plugins exist so resurrect+continuum are functional on first run.
     home.activation.cafayeTmuxPlugins = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
@@ -48,6 +49,16 @@ in
       fi
       if [ -x "$TPM_DIR/bin/install_plugins" ]; then
         run "$TPM_DIR/bin/install_plugins" >/dev/null 2>&1 || true
+      fi
+    '';
+
+    # Ensure tmux italic-capable terminfo exists on every host.
+    home.activation.cafayeTmuxTerminfo = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if command -v ${pkgs.ncurses}/bin/tic >/dev/null 2>&1; then
+        mkdir -p "$HOME/.terminfo"
+        if ! infocmp tmux-256color-italic >/dev/null 2>&1; then
+          run ${pkgs.ncurses}/bin/tic -x -o "$HOME/.terminfo" "$HOME/.config/tmux/tmux-256color-italic.terminfo" >/dev/null 2>&1 || true
+        fi
       fi
     '';
   };

--- a/user/user-state.json.example
+++ b/user/user-state.json.example
@@ -12,7 +12,34 @@
       "bootstrap_mode": false
     },
     "auto_shutdown_enabled": false,
-    "auto_shutdown_idle_minutes": 60
+    "auto_shutdown_idle_minutes": 60,
+    "monitoring": {
+      "enabled": false,
+      "check_interval_minutes": 5,
+      "repeat_alert_minutes": 30,
+      "thresholds": {
+        "ram_percent": 75,
+        "disk_percent": 80,
+        "load_per_core": 0.7
+      },
+      "processes": [
+        "postgresql",
+        "redis"
+      ],
+      "notifier": {
+        "provider": "none",
+        "telegram": {
+          "bot_token": "",
+          "chat_id": ""
+        },
+        "discord": {
+          "webhook_url": ""
+        },
+        "slack": {
+          "webhook_url": ""
+        }
+      }
+    }
   },
   "interface": {
     "terminal": {

--- a/user/user-state.json.example
+++ b/user/user-state.json.example
@@ -38,6 +38,12 @@
         "slack": {
           "webhook_url": ""
         }
+      },
+      "healthcheck_reports": {
+        "frequency": "none",
+        "time": "09:00",
+        "day_of_week": "Mon",
+        "day_of_month": 1
       }
     }
   },

--- a/user/user-state.schema.json
+++ b/user/user-state.schema.json
@@ -46,6 +46,89 @@
                     "maximum": 1440,
                     "default": 60,
                     "description": "Minutes of inactivity before auto-shutdown (1-1440, default 60)"
+                },
+                "monitoring": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "check_interval_minutes": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 60
+                        },
+                        "repeat_alert_minutes": {
+                            "type": "integer",
+                            "minimum": 5,
+                            "maximum": 1440
+                        },
+                        "thresholds": {
+                            "type": "object",
+                            "properties": {
+                                "ram_percent": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 100
+                                },
+                                "disk_percent": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 100
+                                },
+                                "load_per_core": {
+                                    "type": "number",
+                                    "minimum": 0.1
+                                }
+                            }
+                        },
+                        "processes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "notifier": {
+                            "type": "object",
+                            "properties": {
+                                "provider": {
+                                    "enum": [
+                                        "none",
+                                        "telegram",
+                                        "discord",
+                                        "slack"
+                                    ]
+                                },
+                                "telegram": {
+                                    "type": "object",
+                                    "properties": {
+                                        "bot_token": {
+                                            "type": "string"
+                                        },
+                                        "chat_id": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "discord": {
+                                    "type": "object",
+                                    "properties": {
+                                        "webhook_url": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "slack": {
+                                    "type": "object",
+                                    "properties": {
+                                        "webhook_url": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/user/user-state.schema.json
+++ b/user/user-state.schema.json
@@ -127,6 +127,39 @@
                                     }
                                 }
                             }
+                        },
+                        "healthcheck_reports": {
+                            "type": "object",
+                            "properties": {
+                                "frequency": {
+                                    "enum": [
+                                        "none",
+                                        "daily",
+                                        "weekly",
+                                        "monthly"
+                                    ]
+                                },
+                                "time": {
+                                    "type": "string",
+                                    "description": "24h time HH:MM (UTC)"
+                                },
+                                "day_of_week": {
+                                    "enum": [
+                                        "Mon",
+                                        "Tue",
+                                        "Wed",
+                                        "Thu",
+                                        "Fri",
+                                        "Sat",
+                                        "Sun"
+                                    ]
+                                },
+                                "day_of_month": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 31
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
Adds optional alerting + scheduled health snapshots, improves doctor portability, and makes tmux truecolor terminfo reproducible across fresh VPS installs.

## Why
Indie VPS users need proactive reliability checks and reproducible terminal behavior without manual fixes.

## What Changed
- Add threshold-based VPS monitoring with optional Slack/Telegram/Discord notifiers\n- Add scheduled health reports (none/daily/weekly/monthly)\n- Add setup UX and doctor diagnostics for monitoring/report schedules\n- Remove bc dependency from doctor CPU load check\n- Add tmux fallback + auto-install tmux-256color-italic terminfo

## How To Test
- Bash syntax checks for updated scripts\n- Local smoke for monitor modes\n- Remote GCloud VPS install/apply validation\n- tmux startup + terminfo checks on fresh VPS

## Risk
Low-medium: new monitoring scripts/timers and tmux activation path.

## Rollback
Revert this PR; monitoring and terminfo activation are isolated to new script/module paths and tmux user config.

## Ownership
- Primary: kaka-ruto
- Backup: TBD

## Acceptance Criteria
<!-- cleo-ac:start -->
version: 1
name: Acceptance Criteria
criteria:
  - id: c1
    title: Replace with criterion title
    severity: medium
    actors: [core]
    surface: web
    environment: local
    given: Replace with setup state and actor context
    when: Replace with user/system action under test
    then:
      - Replace with observable expected outcome
    evidence_required:
      - replace_with_evidence_artifact
<!-- cleo-ac:end -->

## Observability
- Expected signals: TBD
- Dashboard/alerts: TBD

## Post-Merge Production Commands
<!-- post-merge-commands:start -->
- `None`
<!-- post-merge-commands:end -->
